### PR TITLE
`decayingTaylorGreenVortex`: Improvement to `Allrun` and addition of an `Allclean` script

### DIFF
--- a/decayingTaylorGreenVortex/Allclean
+++ b/decayingTaylorGreenVortex/Allclean
@@ -1,0 +1,13 @@
+#!/bin/bash
+cd "${0%/*}" || exit    # Run from this directory
+
+# Clean the meshmotion library
+wclean -s decayingTaylorGreenVortexMeshMotion
+
+# Clean helper utilities
+wclean -s initialiseTaylorGreenVortex
+wclean -s perturbMeshPoints
+wclean -s smoothlyDistortMeshPoints
+
+echo; echo "Removing all run directories"
+find . -maxdepth 1 -name 'run_*' -type d -print0 | xargs --null rm -rf

--- a/decayingTaylorGreenVortex/Allrun
+++ b/decayingTaylorGreenVortex/Allrun
@@ -157,7 +157,7 @@ do
         elif command -v time &> /dev/null
         then
             echo "Running $SOLVER on ${CASE} with time"
-            gtime -f "Maximum resident set size (kbytes): %M" $SOLVER &> $LOG
+            time -f "Maximum resident set size (kbytes): %M" $SOLVER &> $LOG
         else
             echo "Running $SOLVER on ${CASE}"
             $SOLVER &> $LOG

--- a/decayingTaylorGreenVortex/Allrun
+++ b/decayingTaylorGreenVortex/Allrun
@@ -1,4 +1,5 @@
 #!/bin/bash
+cd "${0%/*}" || exit    # Run from this directory
 
 # Source required functions
 . $WM_PROJECT_DIR/bin/tools/RunFunctions

--- a/decayingTaylorGreenVortex/Allrun
+++ b/decayingTaylorGreenVortex/Allrun
@@ -221,5 +221,5 @@ cd ..
 
 echo; echo; echo "Done!"; echo
 echo "View the PDF files in ${RUN_DIR}"
-echo; echo $(date)
+echo; date
 echo; echo

--- a/decayingTaylorGreenVortex/Allrun
+++ b/decayingTaylorGreenVortex/Allrun
@@ -61,7 +61,7 @@ do
     echo "# Mesh Time Mem U_L1 U_L2 U_Linf" > "${SUMMARY}"
 
     # Loop over mesh densities in each configuration
-    for i in `seq $START_MESH $END_MESH`
+    for i in $(seq $START_MESH $END_MESH)
     do
         CASE="${NAME}.$i"
         echo; echo "Processing case: $CASE"

--- a/decayingTaylorGreenVortex/Allrun
+++ b/decayingTaylorGreenVortex/Allrun
@@ -39,8 +39,8 @@ else
 fi
 
 # Create timestamped working directory for this run
-DATE=$(date +%Y%m%d_%H%M%S)
-RUN_DIR="run_${CPU_TYPE}_${DATE}"
+DATE_TIME=$(date +%Y%m%d_%H%M%S)
+RUN_DIR="run_${CPU_TYPE}_${DATE_TIME}"
 echo "Creating ${RUN_DIR}"
 mkdir "${RUN_DIR}"
 

--- a/decayingTaylorGreenVortex/Allrun
+++ b/decayingTaylorGreenVortex/Allrun
@@ -38,7 +38,6 @@ else
     CPU_TYPE="Unknown_CPU"
 fi
 
-
 # Create timestamped working directory for this run
 DATE=$(date +%Y%m%d_%H%M%S)
 RUN_DIR="run_${CPU_TYPE}_${DATE}"

--- a/decayingTaylorGreenVortex/Allrun
+++ b/decayingTaylorGreenVortex/Allrun
@@ -120,8 +120,8 @@ do
             solids4Foam::runApplication perturbMeshPoints
         fi
 
-        # Initialie the velocity and pressure initial fields with the analytical
-        # solutions
+        # Initialise the velocity and pressure initial fields with the
+        # analytical solutions
         solids4Foam::runApplication initialiseTaylorGreenVortex
 
         # Set the solver


### PR DESCRIPTION
Hi @philipcardiff,

Here are the improvements to `Allrun`:

- Fixed a typo and removed two consecutive newlines.
- Ensured that `Allrun` can only be executed from the directory in which it resides, so that all `run_...` directories are created locally. This simplifies the corresponding `Allclean` script, as there's no need to specify paths to library and utility helpers when running `wclean`. The same approach can be applied to `Allclean` for consistency.
- Renamed a variable for clarity: `$DATE` -> `$DATE_TIME`.
- Replaced legacy backticks with modern `$(...)` syntax.
- Removed redundant `echo` and subshell usage.