### PR TITLE
Bugfix: Plotting for multiple configurations (`decayingTaylorGreenVortex`)

### DIFF
--- a/decayingTaylorGreenVortex/Allrun
+++ b/decayingTaylorGreenVortex/Allrun
@@ -245,14 +245,21 @@ then
 
     # Run all plotting scripts for each config summary
     echo
-    for summary in *summary.txt
+    for script in *gnuplot
     do
-        for script in *gnuplot
+        for datafile in *summary.txt
         do
-            echo "Running gnuplot on $script for $summary"
-            # Pass the config name (parsed from the summary file name) as input
-            # to the script, to be used as the name of the output file.
-            configName="${summary%.summary.txt}"
+            echo "Running gnuplot on $script for $datafile"
+            # Pass the config name as input to the script, to be used as the
+            # name of the output file.
+            configName="${datafile%.summary.txt}"
+            gnuplot -c "$script" "$configName"
+        done
+
+        for datafile in *orderOfAccuracy.txt
+        do
+            echo "Running gnuplot on $script for $datafile"
+            configName="${datafile%.orderOfAccuracy.txt}"
             gnuplot -c "$script" "$configName"
         done
     done

--- a/decayingTaylorGreenVortex/Allrun
+++ b/decayingTaylorGreenVortex/Allrun
@@ -243,25 +243,26 @@ then
     cp ../plotScripts/*gnuplot .
     cp ../plotScripts/orderOfAccuracySlopes*.dat .
 
-    # Run all plotting scripts for each config summary
     echo
-    for script in *gnuplot
-    do
-        for datafile in *summary.txt
-        do
-            echo "Running gnuplot on $script for $datafile"
-            # Pass the config name as input to the script, to be used as the
-            # name of the output file.
-            configName="${datafile%.summary.txt}"
-            gnuplot -c "$script" "$configName"
-        done
 
-        for datafile in *orderOfAccuracy.txt
-        do
-            echo "Running gnuplot on $script for $datafile"
-            configName="${datafile%.orderOfAccuracy.txt}"
-            gnuplot -c "$script" "$configName"
-        done
+    # Run velocity error scripts for each configuration
+    errorScript="velocityErrors.gnuplot "
+    for datafile in *summary.txt
+    do
+        echo "Running gnuplot on $script for $datafile"
+        # Pass the config name as input to the script, to be used as the
+        # name of the output file.
+        configName="${datafile%.summary.txt}"
+        gnuplot -c "$errorScript" "$configName"
+    done
+
+    # Run order of accuracy scripts for each configuration
+    orderOfAccuracyScript="orderOfAccuracyVelocity.gnuplot"
+    for datafile in *orderOfAccuracy.txt
+    do
+        echo "Running gnuplot on $script for $datafile"
+        configName="${datafile%.orderOfAccuracy.txt}"
+        gnuplot -c "$orderOfAccuracyScript" "$configName"
     done
 fi
 

--- a/decayingTaylorGreenVortex/Allrun
+++ b/decayingTaylorGreenVortex/Allrun
@@ -246,7 +246,7 @@ then
     echo
 
     # Run velocity error scripts for each configuration
-    errorScript="velocityErrors.gnuplot "
+    errorScript="velocityErrors.gnuplot"
     for datafile in *summary.txt
     do
         echo "Running gnuplot on $script for $datafile"

--- a/decayingTaylorGreenVortex/Allrun
+++ b/decayingTaylorGreenVortex/Allrun
@@ -243,12 +243,18 @@ then
     cp ../plotScripts/*gnuplot .
     cp ../plotScripts/orderOfAccuracySlopes*.dat .
 
-    # Run all scripts
+    # Run all plotting scripts for each config summary
     echo
-    for f in *gnuplot
+    for summary in *summary.txt
     do
-        echo "Running gnuplot on $f"
-        gnuplot "$f"
+        for script in *gnuplot
+        do
+            echo "Running gnuplot on $script for $summary"
+            # Pass the config name (parsed from the summary file name) as input
+            # to the script, to be used as the name of the output file.
+            configName="${summary%.summary.txt}"
+            gnuplot -c "$script" "$configName"
+        done
     done
 fi
 

--- a/decayingTaylorGreenVortex/plotScripts/orderOfAccuracyVelocity.gnuplot
+++ b/decayingTaylorGreenVortex/plotScripts/orderOfAccuracyVelocity.gnuplot
@@ -1,7 +1,15 @@
 set term pdfcairo dashed enhanced
 set datafile separator " "
 
-set output "velocity_orderOfAccuracy.pdf"
+if (ARGC < 1) {
+    print "Error: No input configuration name provided."
+    print "usage: ", ARG0, " <configName>"
+    exit
+} else {
+    configName = ARG1
+}
+
+set output configName.".velocity_orderOfAccuracy.pdf"
 
 set grid
 set xrange [10:200]
@@ -21,7 +29,7 @@ dx=0.2
 
 # Assume the mesh spacing is being halved for each succesive mesh
 plot \
-    "hex.lu.orderOfAccuracy.txt" using (1e3*dx/(2**($0))):2 skip 1 w lp pt 5 lc "green" t "L_1", \
-    "hex.lu.orderOfAccuracy.txt" using (1e3*dx/(2**($0))):3 skip 1 w lp pt 5 lc "red" t "L_2", \
-    "hex.lu.orderOfAccuracy.txt" using (1e3*dx/(2**($0))):4 skip 1 w lp pt 4 lc "blue" t "L_∞"
+    configName.".orderOfAccuracy.txt" using (1e3*dx/(2**($0))):2 skip 1 w lp pt 5 lc "green" t "L_1", \
+    configName.".orderOfAccuracy.txt" using (1e3*dx/(2**($0))):3 skip 1 w lp pt 5 lc "red" t "L_2", \
+    configName.".orderOfAccuracy.txt" using (1e3*dx/(2**($0))):4 skip 1 w lp pt 4 lc "blue" t "L_∞"
 

--- a/decayingTaylorGreenVortex/plotScripts/orderOfAccuracyVelocity.gnuplot
+++ b/decayingTaylorGreenVortex/plotScripts/orderOfAccuracyVelocity.gnuplot
@@ -25,11 +25,11 @@ set ylabel "Order of accuracy"
 set key bottom left;
 
 # Average mesh spacing of mesh1
-dx=0.2
+dx = 0.2
 
 # Assume the mesh spacing is being halved for each succesive mesh
+datafile = configName.".orderOfAccuracy.txt"
 plot \
-    configName.".orderOfAccuracy.txt" using (1e3*dx/(2**($0))):2 skip 1 w lp pt 5 lc "green" t "L_1", \
-    configName.".orderOfAccuracy.txt" using (1e3*dx/(2**($0))):3 skip 1 w lp pt 5 lc "red" t "L_2", \
-    configName.".orderOfAccuracy.txt" using (1e3*dx/(2**($0))):4 skip 1 w lp pt 4 lc "blue" t "L_∞"
-
+    datafile using (1e3*dx/(2**($0))):2 skip 1 w lp pt 5 lc "green" t "L_1", \
+    datafile using (1e3*dx/(2**($0))):3 skip 1 w lp pt 5 lc "red" t "L_2", \
+    datafile using (1e3*dx/(2**($0))):4 skip 1 w lp pt 4 lc "blue" t "L_∞"

--- a/decayingTaylorGreenVortex/plotScripts/velocityErrors.gnuplot
+++ b/decayingTaylorGreenVortex/plotScripts/velocityErrors.gnuplot
@@ -1,7 +1,15 @@
 set term pdfcairo dashed enhanced
 set datafile separator " "
 
-set output "velocityErrors.pdf"
+if (ARGC < 1) {
+    print "Error: No input configuration name provided."
+    print "usage: ", ARG0, " <configName>"
+    exit
+} else {
+    configName = ARG1
+}
+
+set output configName.".velocityErrors.pdf"
 
 #set size ratio 1
 
@@ -29,8 +37,8 @@ dx=0.2
 
 # Assume the mesh spacing is being halved for each succesive mesh
 plot \
-    "hex.lu.summary.txt" u (1e3*dx/(2**($0))):($4) w lp pt 5 lc "green" t "L_1", \
-    "hex.lu.summary.txt" u (1e3*dx/(2**($0))):($5) w lp pt 15 lc "red" t "L_2", \
-    "hex.lu.summary.txt" u (1e3*dx/(2**($0))):($6) w lp pt 9 lc "blue" t "L_∞", \
+    configName.".summary.txt" u (1e3*dx/(2**($0))):($4) w lp pt 5 lc "green" t "L_1", \
+    configName.".summary.txt" u (1e3*dx/(2**($0))):($5) w lp pt 15 lc "red" t "L_2", \
+    configName.".summary.txt" u (1e3*dx/(2**($0))):($6) w lp pt 9 lc "blue" t "L_∞", \
     "orderOfAccuracySlopesVelocity.dat" u 1:2 w l lw 2 lc "black" notitle, \
     "orderOfAccuracySlopesVelocity.dat" u 1:3 w l lw 2 lc "black" notitle

--- a/decayingTaylorGreenVortex/plotScripts/velocityErrors.gnuplot
+++ b/decayingTaylorGreenVortex/plotScripts/velocityErrors.gnuplot
@@ -30,15 +30,17 @@ set label "1^{st} order" at graph 0.5,0.78 center rotate by 10
 set label "2^{nd} order" at graph 0.5,0.37 center rotate by 25
 
 # Average mesh spacing of mesh1
-dx=0.2
+dx = 0.2
 
 # 15,14 - upturned solid penta
 # 5,4 - square
 
 # Assume the mesh spacing is being halved for each succesive mesh
+datafile = configName.".summary.txt"
+slopfile = "orderOfAccuracySlopesVelocity.dat"
 plot \
-    configName.".summary.txt" u (1e3*dx/(2**($0))):($4) w lp pt 5 lc "green" t "L_1", \
-    configName.".summary.txt" u (1e3*dx/(2**($0))):($5) w lp pt 15 lc "red" t "L_2", \
-    configName.".summary.txt" u (1e3*dx/(2**($0))):($6) w lp pt 9 lc "blue" t "L_∞", \
-    "orderOfAccuracySlopesVelocity.dat" u 1:2 w l lw 2 lc "black" notitle, \
-    "orderOfAccuracySlopesVelocity.dat" u 1:3 w l lw 2 lc "black" notitle
+    datafile u (1e3*dx/(2**($0))):($4) w lp pt 5 lc "green" t "L_1", \
+    datafile u (1e3*dx/(2**($0))):($5) w lp pt 15 lc "red" t "L_2", \
+    datafile u (1e3*dx/(2**($0))):($6) w lp pt 9 lc "blue" t "L_∞", \
+    slopfile u 1:2 w l lw 2 lc "black" notitle, \
+    slopfile u 1:3 w l lw 2 lc "black" notitle


### PR DESCRIPTION
Hi @philipcardiff,

I noticed that the gnuplot scripts contain hardcoded configuration names and output file names. Also, in `Allrun` plots are generated for only one configuration summary (i.e., the one that is hardcoded in the scripts).

This fix iterates through all summary files and passes the corresponding configuration name as the first argument to the scripts.