### PR TITLE
Feature `Allrun`: self-logging

### DIFF
--- a/decayingTaylorGreenVortex/Allrun
+++ b/decayingTaylorGreenVortex/Allrun
@@ -17,7 +17,7 @@ fi
 
 # Log the simulations in the second recursive call to the script when the run
 # directory is already created.
-if [ "$RECURSIVE_CALL" = "false" ]
+if [ "$RECURSIVE_CALL" != "true" ]
 then
     # Create timestamped working directory for this run
     DATE_TIME=$(date +%Y%m%d_%H%M%S)


### PR DESCRIPTION
Hi @philipcardiff,

It would be useful for the script to log its output as it runs. This commit adds that capability by recursion: the script re-invokes itself, and the base case checks whether a specific variable is set (`RECURSIVE_CALL`). Key variables are exported during the initial run so they are available in the recursive call.

The CPU checks and creation of the run directory, based on the current time, is moved to the top of the script so that the script can store the log file in the correct run directory.

Please let me know if you think there's a better approach.