### PR TITLE
Features for perturbed mesh configurations

### DIFF
--- a/decayingTaylorGreenVortex/Allrun
+++ b/decayingTaylorGreenVortex/Allrun
@@ -28,8 +28,9 @@ configs=(
 #                  smoothlyDistortMeshPoints
 # BUMP:            bump or sinusoidal version of smoothlyDistortMeshPoints (if
 #                  SMOOTHLYDISTORT is enabled)
-# PERTURB:         apply a random perturbtation to the initial mesh using
-#                  perturbMeshPoints
+# PERTURB:         Apply a random perturbation to the initial mesh using
+#                  perturbMeshPoints. A value of 0 disables it; any non-zero
+#                  value enables it and is used as the random seed.
 # PIMPLEFOAM:      use the pimpleFoam or solids4Foam solver
 
 # Define start and end mesh indices
@@ -60,6 +61,12 @@ mkdir "${RUN_DIR}"
 
 # Enter the run directory
 cd "${RUN_DIR}"
+
+# If any configuration perturbs the mesh, create a combined summary file
+if [[ "${configs[*]}" =~ PERTURB=([1-9][0-9]*) ]]; then
+    PERTURB_SUMMARIES="perturb_summaries.txt"
+    echo "# Mesh Time Mem U_L1 U_L2 U_Linf" > "${PERTURB_SUMMARIES}"
+fi
 
 # Iterate through configurations
 for config in "${configs[@]}"
@@ -154,9 +161,18 @@ do
             solids4Foam::runApplication smoothlyDistortMeshPoints
         fi
 
-        # Optional mesh distortion
-        if [ "$PERTURB" -eq 1 ]
+        # Optional random mesh perturbation
+        if [ "$PERTURB" -ne 0 ]
         then
+            # Set the seed value for the random number generator
+            if [ $WM_PROJECT = "foam" ]
+            then
+                # Assumes the seed is as an integer
+                sed -i -E "s/^(seed\s+)[0-9]+(;)/\1$PERTURB\2/" system/perturbMeshPointsDict
+            else
+                foamDictionary -entry seed -set "$PERTURB" system/perturbMeshPointsDict
+            fi
+
             solids4Foam::runApplication perturbMeshPoints
         fi
 
@@ -221,6 +237,11 @@ do
 
         # Write data to file
         echo "$i $CLOCK_TIME $MAX_MEMORY $U_L1_ERROR $U_L2_ERROR $U_LINF_ERROR" >> ../"${SUMMARY}"
+
+        if [ "$PERTURB" -ne 0 ]
+        then
+            echo "$i $CLOCK_TIME $MAX_MEMORY $U_L1_ERROR $U_L2_ERROR $U_LINF_ERROR" >> ../"${PERTURB_SUMMARIES}"
+        fi
 
         cd ..
     done

--- a/decayingTaylorGreenVortex/Allrun
+++ b/decayingTaylorGreenVortex/Allrun
@@ -150,7 +150,7 @@ do
                 \cp system/smoothlyDistortMeshPointsDict.sine \
                     system/smoothlyDistortMeshPointsDict
             fi
-                
+
             solids4Foam::runApplication smoothlyDistortMeshPoints
         fi
 

--- a/decayingTaylorGreenVortex/Allrun
+++ b/decayingTaylorGreenVortex/Allrun
@@ -285,6 +285,16 @@ then
         configName="${datafile%.orderOfAccuracy.txt}"
         gnuplot -c "$orderOfAccuracyScript" "$configName"
     done
+
+    # Run the linear fit plot script for perturbation configurations
+    if [ -e "$PERTURB_SUMMARIES" ]
+    then
+        linearFitErrorScript="linearFitVelocityErrors.gnuplot"
+        datafile="$PERTURB_SUMMARIES"
+
+        echo "Running gnuplot on $linearFitErrorScript for $datafile"
+        gnuplot -c "$linearFitErrorScript" "$datafile"
+    fi
 fi
 
 # Exit the run directory

--- a/decayingTaylorGreenVortex/plotScripts/linearFitVelocityErrors.gnuplot
+++ b/decayingTaylorGreenVortex/plotScripts/linearFitVelocityErrors.gnuplot
@@ -1,0 +1,63 @@
+set term pdfcairo dashed enhanced
+set datafile separator " "
+
+if (ARGC < 1) {
+    print "Error: No input configuration name provided."
+    print "usage: ", ARG0, " <configName>"
+    exit
+} else {
+    # Summary of all configurations are combined into one data file
+    datafile = ARG1
+}
+
+set output "linearFitVelocityErrors.pdf"
+slopfile = "orderOfAccuracySlopesVelocity.dat"
+
+set grid
+set xtics add (25, 50, 100, 200)
+set ytics
+set xrange [10:200]
+set yrange [1e-5:0.1]
+set logscale x
+set logscale y
+set format y "10^{%L}"
+set xlabel "Average cell spacing (in mm)"
+set ylabel "Error (in m/s)"
+set key right bottom;
+set key spacing 2 # Adds space between legend entries
+
+set label "1^{st} order" at graph 0.43,0.76 center rotate by 10
+set label "2^{nd} order" at graph 0.43,0.33 center rotate by 22
+
+# Average mesh spacing of mesh1
+dx = 0.2
+
+# A linear function for fitting in log-log space
+g(x) = m * x + c
+
+# Silence verbose fit output
+set fit quiet
+
+# Fit g(x) to the L_1 error data
+set fit logfile "L_1.fit.log"
+fit [0:1000] g(x) datafile using (log(1e3*dx/(2**($1 - 1)))):(log($4)) via m, c
+plot datafile using (1e3*dx/(2**($1 - 1))):4 with points pt 6 lc "red" title "L_1", \
+     x**m * exp(c) with lines lw 2 lc rgb "dark-red" title sprintf("Y = {%.2f}X + %.2g", m, c), \
+     slopfile u 1:2 w l lw 2 lc "gray" notitle, \
+     slopfile u 1:3 w l lw 2 lc "gray" notitle
+
+# Fit g(x) to the L_2 error data
+set fit logfile "L_2.fit.log"
+fit [0:1000] g(x) datafile using (log(1e3*dx/(2**($1 - 1)))):(log($5)) via m, c
+plot datafile using (1e3*dx/(2**($1 - 1))):5 with points pt 6 lc "green" title "L_2", \
+     x**m * exp(c) with lines lw 2 lc rgb "dark-green" title sprintf("Y = {%.2f}X + %.2g", m, c), \
+     slopfile u 1:2 w l lw 2 lc "gray" notitle, \
+     slopfile u 1:3 w l lw 2 lc "gray" notitle
+
+# Fit g(x) to the L_∞ error data
+set fit logfile "L_inf.fit.log"
+fit [0:1000] g(x) datafile using (log(1e3*dx/(2**($1 - 1)))):(log($6)) via m, c
+plot datafile using (1e3*dx/(2**($1 - 1))):6 with points pt 6 lc "blue" title "L_∞", \
+     x**m * exp(c) with lines lw 2 lc rgb "dark-blue" title sprintf("Y = {%.2f}X + %.2g", m, c), \
+     slopfile u 1:2 w l lw 2 lc "gray" notitle, \
+     slopfile u 1:3 w l lw 2 lc "gray" notitle


### PR DESCRIPTION
In short, this PR uses the non-zero value of `PERTURB` as the seed for the random number generator, adds a new plot script, and updates `Allrun` to run the script for all perturbation cases.

---

Now, setting `PERTURB` to zero disables mesh perturbation, while any nonzero value serves as the seed for the random number generator.

```bash
configs=(
    "BASE=base NAME=hex.lu.p1 GRADED=0 \
    MOVING=0 ORTHOGONAL=0 \
    SMOOTHLYDISTORT=0 PERTURB=1 BUMP=0 \
    PIMPLEFOAM=1"

    "BASE=base NAME=hex.lu.p2 GRADED=0 \
    MOVING=0 ORTHOGONAL=0 \
    SMOOTHLYDISTORT=0 PERTURB=2 BUMP=0 \
    PIMPLEFOAM=1"

    "BASE=base NAME=hex.lu.p3 GRADED=0 \
    MOVING=0 ORTHOGONAL=0 \
    SMOOTHLYDISTORT=0 PERTURB=3 BUMP=0 \
    PIMPLEFOAM=1"

    ...
)
```

---

In `Allrun`, if there are any configurations with a perturbed mesh, a `perturb_summaries.txt` file is created to collect all summaries related only to those configurations.

In the plotting section of `Allrun`, it checks for the existence of `perturb_summaries.txt` and runs the linear fit plot script only if the file is present.

(For the plot section, I couldn't simply rely on the value of `PERTURB` to determine whether the linear fit plot should be generated, because if the last configuration in `configs` does not perturb the mesh (i.e., `PERTURB=0`), it would prevent the plot script from running. To fix this, I collect all summaries related to perturbed mesh configurations into one file and use its existence as the trigger for plotting.)

---

The new plot script expects `perturb_summaries.txt`. It fits a linear model $g(x) = mx + c$ to the log-transformed data ($\log(x)$ and $\log(y)$ ) for each error norm, effectively modeling a power-law relationship $\text{error} = A\ \text{spacing}^m$, where $A = \exp(c)$. Fit output is suppressed in the console but saved to separate log files for each norm.
