### PR TITLE
Development OCC: Rename Boundaries + Improve Mesh Grading

### DIFF
--- a/oscillatingCircularCylinder/base/0/U
+++ b/oscillatingCircularCylinder/base/0/U
@@ -22,7 +22,7 @@ internalField   uniform (0 0 0);
 
 boundaryField
 {
-    cylinderWall
+    cylinder
     {
         type            movingWallVelocity;
         value           uniform (0 0 0);

--- a/oscillatingCircularCylinder/base/0/pointDisplacement
+++ b/oscillatingCircularCylinder/base/0/pointDisplacement
@@ -22,7 +22,7 @@ internalField   uniform (0 0 0);
 
 boundaryField
 {
-    cylinderWall
+    cylinder
     {
 #if 0
         name    pointDisplacement_cylinder;
@@ -63,20 +63,20 @@ boundaryField
 #endif
     }
 
-    walls
+    slipWalls
     {
         type    slip;
+    }
+
+    noSlipWalls
+    {
+        type    fixedValue;
+        value   $internalField;
     }
 
     frontAndBack
     {
         type    empty;
-    }
-
-    ".*"
-    {
-        type    fixedValue;
-        value   $internalField;
     }
 }
 

--- a/oscillatingCircularCylinder/base/Allrun
+++ b/oscillatingCircularCylinder/base/Allrun
@@ -41,6 +41,7 @@ fi
 #              1) using the data from `forces` function object,
 #              2) using the data from `forceCoeffs` function object.
 cp ../plotScripts/*.gnuplot .
+cp ../validationData/*.dat .
 
 for script in ./*.gnuplot
 do

--- a/oscillatingCircularCylinder/base/system/blockMeshDict
+++ b/oscillatingCircularCylinder/base/system/blockMeshDict
@@ -159,38 +159,50 @@ defaultPatch
 
 boundary
 (
-    inlet
+    left
     {
-        type patch;
+        type wall;
+        inGroups (noSlipWalls);
         faces
         (
             (8 0 12 20)
         );
     }
-    outlet
+    right
     {
-        type patch;
+        type wall;
+        inGroups (noSlipWalls);
         faces
         (
             (3 11 23 15)
         );
     }
-    walls
+    up
     {
         type wall;
+        inGroups (slipWalls);
         faces
         (
-            ( 0  1 13 12)
-            ( 1  2 14 13)
-            ( 2  3 15 14)
             ( 9  8 20 21)
             (10  9 21 22)
             (11 10 22 23)
         );
     }
-    cylinderWall
+    down
     {
         type wall;
+        inGroups (slipWalls);
+        faces
+        (
+            (0 1 13 12)
+            (1 2 14 13)
+            (2 3 15 14)
+        );
+    }
+    cylinder
+    {
+        type wall;
+        inGroups (movingWall);
         faces
         (
             (4 6 18 16)

--- a/oscillatingCircularCylinder/base/system/blockMeshDict.graded
+++ b/oscillatingCircularCylinder/base/system/blockMeshDict.graded
@@ -239,38 +239,50 @@ defaultPatch
 
 boundary
 (
-    inlet
+    left
     {
-        type patch;
+        type wall;
+        inGroups (noSlipWalls);
         faces
         (
             (8 0 12 20)
         );
     }
-    outlet
+    right
     {
-        type patch;
+        type wall;
+        inGroups (noSlipWalls);
         faces
         (
             (3 11 23 15)
         );
     }
-    walls
+    up
     {
         type wall;
+        inGroups (slipWalls);
         faces
         (
-            ( 0  1 13 12)
-            ( 1  2 14 13)
-            ( 2  3 15 14)
             ( 9  8 20 21)
             (10  9 21 22)
             (11 10 22 23)
         );
     }
-    cylinderWall
+    down
     {
         type wall;
+        inGroups (slipWalls);
+        faces
+        (
+            (0 1 13 12)
+            (1 2 14 13)
+            (2 3 15 14)
+        );
+    }
+    cylinder
+    {
+        type wall;
+        inGroups (movingWall);
         faces
         (
             (4  6 18 16)

--- a/oscillatingCircularCylinder/base/system/blockMeshDict.graded
+++ b/oscillatingCircularCylinder/base/system/blockMeshDict.graded
@@ -118,7 +118,7 @@ downstreamCells $upstreamCells;
 blocks
 (
     // Upstream block
-    hex ( 0 1 9 8 12 13 21 20 ) $upstreamCells
+    hex (0 1 9 8 12 13 21 20) $upstreamCells
     simpleGrading
     (
         (
@@ -135,7 +135,7 @@ blocks
     // Surrounding Box blocks
 
         // West of cylinder
-        hex ( 1 4 6 9 13 16 18 21 ) $cylinderCells
+        hex (1 4 6 9 13 16 18 21) $cylinderCells
         simpleGrading
         (
             (
@@ -152,7 +152,7 @@ blocks
         )
 
         // South of cylinder
-        hex ( 1 2 5 4 13 14 17 16 ) $cylinderCells
+        hex (1 2 5 4 13 14 17 16) $cylinderCells
         simpleGrading
         (
             (
@@ -169,7 +169,7 @@ blocks
         )
 
         // East of cylinder
-        hex ( 2 10 7 5 14 22 19 17 ) $cylinderCells
+        hex (2 10 7 5 14 22 19 17) $cylinderCells
         simpleGrading
         (
             (
@@ -186,7 +186,7 @@ blocks
         )
 
         // North of cylinder
-        hex ( 6 7 10 9 18 19 22 21 ) $cylinderCells
+        hex (6 7 10 9 18 19 22 21) $cylinderCells
         simpleGrading
         (
             (
@@ -285,10 +285,10 @@ boundary
         inGroups (movingWall);
         faces
         (
-            (4  6 18 16)
-            (5  4 16 17)
-            (7  5 17 19)
-            (6  7 19 18)
+            (4 6 18 16)
+            (5 4 16 17)
+            (7 5 17 19)
+            (6 7 19 18)
         );
     }
 );

--- a/oscillatingCircularCylinder/base/system/blockMeshDict.graded
+++ b/oscillatingCircularCylinder/base/system/blockMeshDict.graded
@@ -122,7 +122,9 @@ blocks
     simpleGrading
     (
         (
-            (1 1 0.125)
+            (0.3 0.375 4)
+            (0.4 0.25 1)
+            (0.3 0.375 0.25)
         )
         (
             (0.25 0.3 2)
@@ -203,11 +205,13 @@ blocks
         )
 
     // Downstream block
-    hex ( 2 3 11 10 14 15 23 22 ) $downstreamCells
+    hex (2 3 11 10 14 15 23 22) $downstreamCells
     simpleGrading
     (
         (
-            (1 1 8)
+            (0.3 0.375 4)
+            (0.4 0.25 1)
+            (0.3 0.375 0.25)
         )
         (
             (0.25 0.3 2)

--- a/oscillatingCircularCylinder/base/system/blockMeshDict.uniform
+++ b/oscillatingCircularCylinder/base/system/blockMeshDict.uniform
@@ -159,38 +159,50 @@ defaultPatch
 
 boundary
 (
-    inlet
+    left
     {
-        type patch;
+        type wall;
+        inGroups (noSlipWalls);
         faces
         (
             (8 0 12 20)
         );
     }
-    outlet
+    right
     {
-        type patch;
+        type wall;
+        inGroups (noSlipWalls);
         faces
         (
             (3 11 23 15)
         );
     }
-    walls
+    up
     {
         type wall;
+        inGroups (slipWalls);
         faces
         (
-            ( 0  1 13 12)
-            ( 1  2 14 13)
-            ( 2  3 15 14)
             ( 9  8 20 21)
             (10  9 21 22)
             (11 10 22 23)
         );
     }
-    cylinderWall
+    down
     {
         type wall;
+        inGroups (slipWalls);
+        faces
+        (
+            (0 1 13 12)
+            (1 2 14 13)
+            (2 3 15 14)
+        );
+    }
+    cylinder
+    {
+        type wall;
+        inGroups (movingWall);
         faces
         (
             (4 6 18 16)


### PR DESCRIPTION
Changes in this PR:

- Rename boundaries to match those in the `oscillatingCylinderInChannel.geo` file
- Add mulit-grading in the x direction
- Minor formatting for consistency